### PR TITLE
Minor bug fix: correcting unintended fall through

### DIFF
--- a/src/object_size.cpp
+++ b/src/object_size.cpp
@@ -127,6 +127,7 @@ double object_size_rec(SEXP x, Environment base_env, std::set<SEXP>& seen) {
       size += object_size_rec(PRVALUE(x), base_env, seen);
       size += object_size_rec(PRCODE(x), base_env, seen);
       size += object_size_rec(PRENV(x), base_env, seen);
+      break;
 
     case EXTPTRSXP:
       size += sizeof(void *); // the actual pointer


### PR DESCRIPTION
This throws an error when compiling with `clang -Werror,-Wimplicit-fallthrough`. It appears to just be a small oversight.
